### PR TITLE
Add optional span attribute configs for Prisma Client

### DIFF
--- a/packages/instrumentation-prisma-client/README.md
+++ b/packages/instrumentation-prisma-client/README.md
@@ -31,5 +31,11 @@ registerInstrumentations({
 });
 ```
 
+## Configuration
+
+| Name                     | Type                                               | Default Value               | Description                                        |  |
+|--------------------------|----------------------------------------------------|-----------------------------|----------------------------------------------------|--|
+| spanAttributes | <code>Attributes</code> | `undefined` | An optional set of Opentelemetry Attributes to be added to the span. For example `spanAttributes: {[SemanticAttributes.DB_SYSTEM]: 'postgresql'}` |  |
+
 ## License
 Apache 2.0 - See [LICENSE](https://github.com/justindsmith/opentelemetry-instrumentation-js/blob/main/LICENSE) for more information.

--- a/packages/instrumentation-prisma-client/src/instrumentation.ts
+++ b/packages/instrumentation-prisma-client/src/instrumentation.ts
@@ -15,7 +15,7 @@ export interface PrismaClientInstrumentationConfig extends InstrumentationConfig
   /**
    * Attibute set to be added to each database span.
    */
-  spanAttributes?: Attributes
+  spanAttributes?: Attributes;
 }
 
 export class PrismaClientInstrumentation extends InstrumentationBase {
@@ -62,8 +62,8 @@ export class PrismaClientInstrumentation extends InstrumentationBase {
             parameters: {
               values: Array<string>;
               __prismaRawParameters__: boolean;
-            }
-          }
+            };
+          };
         };
 
         const span = plugin.tracer.startSpan(
@@ -79,11 +79,8 @@ export class PrismaClientInstrumentation extends InstrumentationBase {
         );
 
         // Add the supplied attributes from instrumentation configuration
-        const {
-          spanAttributes: spanAttributes,
-        } = plugin.getConfig()
-        span.setAttributes(spanAttributes)
-
+        const { spanAttributes: spanAttributes } = plugin.getConfig();
+        span.setAttributes(spanAttributes);
 
         return opentelemetry.context.with(opentelemetry.trace.setSpan(opentelemetry.context.active(), span), () => {
           const promiseResponse = original.apply(this, arguments as any) as Promise<any>;


### PR DESCRIPTION
Hi @justindsmith,

Firstly, thank you for helping me out with https://github.com/justindsmith/opentelemetry-instrumentations-js/issues/17, that was really quick!

I wanted to be able to have some helpful span attributes for the DB spans, but I saw there was a limit to information available in the `_request` method that this instrumentation patches (except for 'query' which I'll get to).

The first thing I tried was using the `$do()` method that Prisma provides, along with a
```
const span = opentelemetry.trace.getSpan(opentelemetry.context.active());
```
call, but it seems like the span is created and and finalized before `$do()` is called.

So I thought it might make sense to allow these attributes to be provided as configuration, which is what I've done here. I've added `peer.service` solely because I'm sending these spans to AWS XRay, and if you don't set one of [peer.service, aws.service, db.service, service.name + span.kind=server], it will set the remote service name to the span name, so the remote service will be called "queryRaw", or something similar.

I also changed span name from clientMethod to action, so instead of something like `$queryRaw` it will be `queryRaw`.

Lastly, I've also added the query string as the `db.connection_string` semantic convention attribute. I realise that this might be controversial (as it might contain sensitive information), so I'm wondering if you think it might be a good idea to make this optional via a config option. Otherwise I think it's really handy to have this as an attribute.

After this change, this is what the span looks like, as an example:
```
{
  traceId: '62c44fbb3ad60e5246fb9b56d7562156',
  parentId: 'c4ed5d9ed721e568',
  name: 'queryRaw',
  id: 'eb3f42f5502f04d8',
  kind: 2,
  timestamp: 1657032635058215,
  duration: 83590,
  attributes: {
    component: 'prisma',
    'db.statement': 'SELECT client_addr, query, state FROM pg_stat_activity;',
    'db.system': 'postgresql',
    'db.connection_string': 'postgres://postgres:******@localhost:5432/mhv?schema=public&pool_timeout=15',
    'peer.service': 'AWS_RDS'
  },
  status: { code: 0 },
  events: [],
  links: []
}
```