### PR TITLE
Update @opentelemetry/instrumentation to ^0.34.0

### DIFF
--- a/packages/instrumentation-prisma-client/package.json
+++ b/packages/instrumentation-prisma-client/package.json
@@ -38,12 +38,12 @@
     "@opentelemetry/api": "^1.0.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.29.2",
+    "@opentelemetry/instrumentation": "^0.34.0",
     "@opentelemetry/semantic-conventions": "^1.3.1"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.1.0",
-    "@opentelemetry/core": "1.3.1",
+    "@opentelemetry/api": "^1.1.0",
+    "@opentelemetry/core": "^1.3.1",
     "@prisma/client": "^3.8.1",
     "@types/lodash": "^4.14.168",
     "@types/mocha": "^8.2.2",

--- a/packages/instrumentation-remix/package.json
+++ b/packages/instrumentation-remix/package.json
@@ -38,15 +38,15 @@
     "@opentelemetry/api": "^1.0.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.29.2",
+    "@opentelemetry/instrumentation": "^0.34.0",
     "@opentelemetry/semantic-conventions": "^1.3.1"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.1.0",
-    "@opentelemetry/core": "1.3.1",
-    "@remix-run/node": "1.10.1",
-    "@remix-run/router": "1.2.1",
-    "@remix-run/server-runtime": "1.10.1",
+    "@opentelemetry/api": "^1.1.0",
+    "@opentelemetry/core": "^1.3.1",
+    "@remix-run/node": "^1.10.1",
+    "@remix-run/router": "^1.2.1",
+    "@remix-run/server-runtime": "^1.10.1",
     "@types/lodash": "^4.14.168",
     "@types/mocha": "^8.2.2",
     "@types/react": "^17.0.38",

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,17 +942,10 @@
   resolved "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.27.0.tgz"
   integrity sha512-tB79288bwjkdhPNpw4UdOEy3bacVwtol6Que7cAu8KEJ9ULjRfSiwpYEwJY/oER3xZ7zNFz0uiJ7N1jSiotpVA==
 
-"@opentelemetry/api-metrics@0.29.2":
-  version "0.29.2"
-  resolved "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz"
-  integrity sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==
-  dependencies:
-    "@opentelemetry/api" "^1.0.0"
-
-"@opentelemetry/api@1.1.0", "@opentelemetry/api@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz"
-  integrity sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==
+"@opentelemetry/api@^1.1.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.4.0.tgz#2c91791a9ba6ca0a0f4aaac5e45d58df13639ac8"
+  integrity sha512-IgMK9i3sFGNUqPMbjABm0G26g0QCKCUBfglhQ7rQq6WcxbKfEHRcmwsoER4hZcuYqJgkYn2OeuoJIv7Jsftp7g==
 
 "@opentelemetry/context-async-hooks@1.0.1":
   version "1.0.1"
@@ -966,12 +959,12 @@
   dependencies:
     "@opentelemetry/semantic-conventions" "1.0.1"
 
-"@opentelemetry/core@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz"
-  integrity sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==
+"@opentelemetry/core@^1.3.1":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.9.0.tgz#5b1d87882a9a76cb3dd7703d6341f21a1ead9368"
+  integrity sha512-Koy1ApRUp5DB5KpOqhDk0JjO9x6QeEkmcePl8qQDsXZGF4MuHUBShXibd+J2tRNckTsvgEHi1uEuUckDgN+c/A==
   dependencies:
-    "@opentelemetry/semantic-conventions" "1.3.1"
+    "@opentelemetry/semantic-conventions" "1.9.0"
 
 "@opentelemetry/exporter-jaeger@^1.0.1":
   version "1.0.1"
@@ -993,12 +986,11 @@
     semver "^7.3.2"
     shimmer "^1.2.1"
 
-"@opentelemetry/instrumentation@^0.29.2":
-  version "0.29.2"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.29.2.tgz"
-  integrity sha512-LXx5V0ONNATQFCE8C5uqnxWSm4rcXLssdLHdXjtGdxRmURqj/JO8jYefqXCD0LzsqEQ6yxOx2GZ0dgXvhBVdTw==
+"@opentelemetry/instrumentation@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz#bae86da46ea4466594689975cd10f0c3720b4071"
+  integrity sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==
   dependencies:
-    "@opentelemetry/api-metrics" "0.29.2"
     require-in-the-middle "^5.0.3"
     semver "^7.3.2"
     shimmer "^1.2.1"
@@ -1051,7 +1043,12 @@
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz"
   integrity sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==
 
-"@opentelemetry/semantic-conventions@1.3.1", "@opentelemetry/semantic-conventions@^1.3.1":
+"@opentelemetry/semantic-conventions@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.0.tgz#461a6061bc14922bb6ef268f883ac1afacc17e04"
+  integrity sha512-po7penSfQ/Z8352lRVDpaBrd9znwA5mHGqXR7nDEiVnxkDFkBIhVf/tKeAJDIq/erFpcRowKFeCsr5eqqcSyFQ==
+
+"@opentelemetry/semantic-conventions@^1.3.1":
   version "1.3.1"
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz"
   integrity sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==
@@ -1068,12 +1065,12 @@
   resolved "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz"
   integrity sha512-G2JH6yWt6ixGKmsRmVgaQYahfwMopim0u/XLIZUo2o/mZ5jdu7+BL+2V5lZr7XiG1axhyrpvlyqE/c0OgYSl3g==
 
-"@remix-run/node@1.10.1":
-  version "1.10.1"
-  resolved "https://registry.npmjs.org/@remix-run/node/-/node-1.10.1.tgz"
-  integrity sha512-MnBkI/peNHs94ipw2SpX5wdY0kQOCtdfufuo9iq7W2zrrUEdRBXJyfkxU/zvzYZbtTwWKwo0g8irZKz88r4oEg==
+"@remix-run/node@^1.10.1":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/node/-/node-1.11.0.tgz#c28ad550ed811e5806c443baf1b54650eb72c7d8"
+  integrity sha512-9tryyo7kBPvKpdThq/uYNERm9meFkP2eDkMW4QOR5sRSlUaMeL6CJwrur7+2ECKC812OhFWV3FJZbnyencOGVg==
   dependencies:
-    "@remix-run/server-runtime" "1.10.1"
+    "@remix-run/server-runtime" "1.11.0"
     "@remix-run/web-fetch" "^4.3.2"
     "@remix-run/web-file" "^3.0.2"
     "@remix-run/web-stream" "^1.0.3"
@@ -1088,12 +1085,17 @@
   resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.2.1.tgz"
   integrity sha512-XiY0IsyHR+DXYS5vBxpoBe/8veTeoRpMHP+vDosLZxL5bnpetzI0igkxkLZS235ldLzyfkxF+2divEwWHP3vMQ==
 
-"@remix-run/server-runtime@1.10.1":
-  version "1.10.1"
-  resolved "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.10.1.tgz"
-  integrity sha512-TTuaQP0MzoTyX/jaGhLOU5VAlUVBQ7Ke1rF0DnP/2rRHEV1PX9fbNtqpp0AZt9Fw0+nCTYODPgDY77S6PDCvXg==
+"@remix-run/router@1.3.0", "@remix-run/router@^1.2.1":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.0.tgz#b6ee542c7f087b73b3d8215b9bf799f648be71cb"
+  integrity sha512-nwQoYb3m4DDpHTeOwpJEuDt8lWVcujhYYSFGLluC+9es2PyLjm+jjq3IeRBQbwBtPLJE/lkuHuGHr8uQLgmJRA==
+
+"@remix-run/server-runtime@1.11.0", "@remix-run/server-runtime@^1.10.1":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/server-runtime/-/server-runtime-1.11.0.tgz#95949378ed057f9e101cf7b673eb40e6906ceff3"
+  integrity sha512-6yP6d5KXRSwMgydKkwXi+B2sqDkCVn0/DgflHz8F0jRxnBn2ZWW1T9QTQdaXO3yL+wI6h4MN++TUbK/yiz40IA==
   dependencies:
-    "@remix-run/router" "1.2.1"
+    "@remix-run/router" "1.3.0"
     "@types/cookie" "^0.4.0"
     "@web3-storage/multipart-parser" "^1.0.0"
     cookie "^0.4.1"


### PR DESCRIPTION
Fixes this warning:

    npm WARN deprecated @opentelemetry/api-metrics@0.29.2: Please use @opentelemetry/api >= 1.3.0