### PR TITLE
chore: add an error attribute to span if response code is 500

### DIFF
--- a/packages/instrumentation-remix/src/instrumentation.ts
+++ b/packages/instrumentation-remix/src/instrumentation.ts
@@ -231,6 +231,9 @@ export class RemixInstrumentation extends InstrumentationBase {
           );
           return originalResponsePromise
             .then((response) => {
+              if (response.status === 500) {
+                span.setAttribute("error", true);
+              }    
               addResponseAttributesToSpan(span, response);
               return response;
             })


### PR DESCRIPTION
When a GET remix.request returns a 500 status code, somehow it doesn't end up in the catch block. Due to this the server response is not marked as an error and there is no error stack trace as well. 

I'm fairly new to open telemetry and I maybe wrong about this. Should there be any other way to handle the internal server error returned by remix.request instance? 