### PR TITLE
fix(prisma-client): span attributes throws if it is  null or undefined

### DIFF
--- a/packages/instrumentation-prisma-client/src/instrumentation.ts
+++ b/packages/instrumentation-prisma-client/src/instrumentation.ts
@@ -80,7 +80,7 @@ export class PrismaClientInstrumentation extends InstrumentationBase {
 
         // Add the supplied attributes from instrumentation configuration
         const { spanAttributes: spanAttributes } = plugin.getConfig();
-        span.setAttributes(spanAttributes);
+        span.setAttributes(spanAttributes || {});
 
         return opentelemetry.context.with(opentelemetry.trace.setSpan(opentelemetry.context.active(), span), () => {
           const promiseResponse = original.apply(this, arguments as any) as Promise<any>;


### PR DESCRIPTION
Currently `span.setAttributes` throws a TypeError if `spanAttributes` is null or undefined. I'm using `import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';` to setup the tracer.

```bash

[Nest] 76317  - 01/31/2023, 10:59:34 AM   ERROR [ExceptionsHandler] Cannot convert undefined or null to object
TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at Span.setAttributes (/mnt/thunder/projects/sandbox/tmp/mcj-nest-example-proj/packages/my-service/server/node_modules/@opentelemetry/sdk-trace-base/src/Span.ts:151:33)
    at PrismaService.patchedRequest (/mnt/thunder/projects/sandbox/tmp/mcj-nest-example-proj/packages/my-service/server/node_modules/opentelemetry-instrumentation-prisma-client/src/instrumentation.ts:85:9)
    at requestFn (/mnt/thunder/projects/sandbox/tmp/mcj-nest-example-proj/packages/my-service/server/node_modules/@prisma/client/runtime/index.js:33885:65)
    at /mnt/thunder/projects/sandbox/tmp/mcj-nest-example-proj/packages/my-service/server/node_modules/@prisma/client/runtime/index.js:33903:18
    at _callback (/mnt/thunder/projects/sandbox/tmp/mcj-nest-example-proj/packages/my-service/server/node_modules/@prisma/client/runtime/index.js:33545:54)
    at Proxy.then (/mnt/thunder/projects/sandbox/tmp/mcj-nest-example-proj/packages/my-service/server/node_modules/@prisma/client/runtime/index.js:33554:14)
    ```