### PR TITLE
Fix tests for `@remix/server-runtime` 1.9.1

### DIFF
--- a/packages/instrumentation-remix/test/instrumentation-remix.spec.ts
+++ b/packages/instrumentation-remix/test/instrumentation-remix.spec.ts
@@ -74,6 +74,7 @@ let build: ServerBuild = {
   entry: {
     module: entryModule,
   },
+  future: {},
 } as unknown as ServerBuild;
 
 /**


### PR DESCRIPTION
A `v2_errorBoundary` future flag was added, but the possibility that the `future` property itself could be `undefined` was not accounted for.