### PR TITLE
Add `http.route` to request handler spans

### DIFF
--- a/packages/instrumentation-remix/README.md
+++ b/packages/instrumentation-remix/README.md
@@ -45,9 +45,9 @@ registerInstrumentations({
 ### requestHandler
 Emitted for every request into remix server.
 
-| Operation       |
-|-----------------|
-| `remix.request` |
+| Operation                   | Example                        | Notes                                                                               |
+|-----------------------------|--------------------------------|-------------------------------------------------------------------------------------|
+| `remix.request [routePath]` | `remix.request /jokes/:jokeId` | If the request does not match a route, the name of the span will be `remix.request` |
 
 
 | Attribute              | Description                                                            | Example Value                                                |
@@ -55,7 +55,9 @@ Emitted for every request into remix server.
 | `code.function`        | Name of executed function                                              | `"requestHandler"`                                           |
 | `http.method`          | HTTP method                                                            | `"POST"`                                                     |
 | `http.url`             | HTTP URL                                                               | `"https://remix.jokes/jokes/new?_data=routes%2Fjokes%2Fnew"` |
+| `http.route`           | HTTP route path, added if the request matches a route                  | `"/jokes/:jokeId"`                                           |
 | `http.status_code`     | Response status code                                                   | `200`                                                        |
+| `match.route.id`       | Remix matched route ID, added if the request matches a route           | `"routes/jokes/$jokeId"`                                     |
 | `error`                | Added if error detected and if `legacyErrorAttributes` enabled         | `true`                                                       |
 | `exception.message`    | Error message, if `legacyErrorAttributes` enabled and if applicable    | `"Kaboom!"`                                                  |
 | `exception.stacktrace` | Error stacktrace, if `legacyErrorAttributes` enabled and if applicable | [stacktrace]                                                 |

--- a/packages/instrumentation-remix/src/instrumentation.ts
+++ b/packages/instrumentation-remix/src/instrumentation.ts
@@ -8,7 +8,11 @@ import {
 import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
 
 import type * as remixRunServerRuntime from "@remix-run/server-runtime";
+import type * as remixRunServerRuntimeRouteMatching from "@remix-run/server-runtime/dist/routeMatching";
+import type { RouteMatch } from "@remix-run/server-runtime/dist/routeMatching";
+import type { ServerRoute } from "@remix-run/server-runtime/dist/routes";
 import type * as remixRunServerRuntimeData from "@remix-run/server-runtime/dist/data";
+
 import type { Params } from "@remix-run/router";
 
 import { VERSION } from "./version";
@@ -70,6 +74,48 @@ export class RemixInstrumentation extends InstrumentationBase {
       },
       (moduleExports: typeof remixRunServerRuntime) => {
         this._unwrap(moduleExports, "createRequestHandler");
+      }
+    );
+
+    const remixRunServerRuntimeRouteMatchingModule = new InstrumentationNodeModuleDefinition<
+      typeof remixRunServerRuntimeRouteMatching
+    >(
+      "@remix-run/server-runtime/dist/routeMatching",
+      ["1.6.2 - 1.x"],
+      (moduleExports: typeof remixRunServerRuntimeRouteMatching) => {
+        // createRequestHandler
+        if (isWrapped(moduleExports["matchServerRoutes"])) {
+          this._unwrap(moduleExports, "matchServerRoutes");
+        }
+        this._wrap(moduleExports, "matchServerRoutes", this._patchMatchServerRoutes());
+
+        return moduleExports;
+      },
+      (moduleExports: typeof remixRunServerRuntimeRouteMatching) => {
+        this._unwrap(moduleExports, "matchServerRoutes");
+      }
+    );
+
+    /*
+     * Before Remix v1.6.2 we needed to wrap `@remix-run/server-runtime/routeMatching` module import instead of
+     * `@remix-run/server-runtime/dist/routeMatching` module import. The wrapping logic is all the same though.
+     */
+    const remixRunServerRuntimeRouteMatchingPre_1_6_2_Module = new InstrumentationNodeModuleDefinition<
+      typeof remixRunServerRuntimeRouteMatching
+    >(
+      "@remix-run/server-runtime/routeMatching",
+      ["1.0 - 1.6.1"],
+      (moduleExports: typeof remixRunServerRuntimeRouteMatching) => {
+        // createRequestHandler
+        if (isWrapped(moduleExports["matchServerRoutes"])) {
+          this._unwrap(moduleExports, "matchServerRoutes");
+        }
+        this._wrap(moduleExports, "matchServerRoutes", this._patchMatchServerRoutes());
+
+        return moduleExports;
+      },
+      (moduleExports: typeof remixRunServerRuntimeRouteMatching) => {
+        this._unwrap(moduleExports, "matchServerRoutes");
       }
     );
 
@@ -208,11 +254,39 @@ export class RemixInstrumentation extends InstrumentationBase {
 
     return [
       remixRunServerRuntimeModule,
+      remixRunServerRuntimeRouteMatchingModule,
+      remixRunServerRuntimeRouteMatchingPre_1_6_2_Module,
       remixRunServerRuntimeDataPre_1_6_2_Module,
       remixRunServerRuntimeDataPre_1_7_2_Module,
       remixRunServerRuntimeDataPre_1_7_6_Module,
       remixRunServerRuntimeDataModule,
     ];
+  }
+
+  private _patchMatchServerRoutes(): (original: typeof remixRunServerRuntimeRouteMatching.matchServerRoutes) => any {
+    const plugin = this;
+    return function matchServerRoutes(original) {
+      return function patchMatchServerRoutes(this: any): RouteMatch<ServerRoute> {
+        const result = original.apply(this, arguments as any);
+
+        const span = opentelemetry.trace.getSpan(opentelemetry.context.active());
+
+        const route = (result || []).slice(-1)[0]?.route;
+
+        const routePath = route?.path;
+        if (span && routePath) {
+          span.setAttribute(SemanticAttributes.HTTP_ROUTE, routePath);
+          span.updateName(`remix.request ${routePath}`);
+        }
+
+        const routeId = route?.id;
+        if (span && routeId) {
+          span.setAttribute(RemixSemanticAttributes.MATCH_ROUTE_ID, routeId);
+        }
+
+        return result;
+      };
+    };
   }
 
   private _patchCreateRequestHandler(): (original: typeof remixRunServerRuntime.createRequestHandler) => any {


### PR DESCRIPTION
Even when a route does not have a loader or an action, it can still be useful to know the route that it matched on. This commit adds an `http.route` attribute to the request handler spans.