### PR TITLE
chore(deps): update OpenTelemetry dependencies

### DIFF
--- a/packages/instrumentation-prisma-client/package.json
+++ b/packages/instrumentation-prisma-client/package.json
@@ -35,15 +35,15 @@
     "url": "https://github.com/justindsmith/opentelemetry-instrumentations-js/issues"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.4"
+    "@opentelemetry/api": "^1.6.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.29.2",
-    "@opentelemetry/semantic-conventions": "^1.3.1"
+    "@opentelemetry/instrumentation": "^0.43.0",
+    "@opentelemetry/semantic-conventions": "^1.17.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.1.0",
-    "@opentelemetry/core": "1.3.1",
+    "@opentelemetry/api": "^1.6.0",
+    "@opentelemetry/core": "^1.17.0",
     "@prisma/client": "^3.8.1",
     "@types/lodash": "^4.14.168",
     "@types/mocha": "^8.2.2",

--- a/packages/instrumentation-prisma-client/package.json
+++ b/packages/instrumentation-prisma-client/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/justindsmith/opentelemetry-instrumentations-js/issues"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.6.0"
+    "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.43.0",

--- a/packages/instrumentation-remix/package.json
+++ b/packages/instrumentation-remix/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/justindsmith/opentelemetry-instrumentations-js/issues"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.6.0"
+    "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.43.0",

--- a/packages/instrumentation-remix/package.json
+++ b/packages/instrumentation-remix/package.json
@@ -35,15 +35,15 @@
     "url": "https://github.com/justindsmith/opentelemetry-instrumentations-js/issues"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.4"
+    "@opentelemetry/api": "^1.6.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.29.2",
-    "@opentelemetry/semantic-conventions": "^1.3.1"
+    "@opentelemetry/instrumentation": "^0.43.0",
+    "@opentelemetry/semantic-conventions": "^1.17.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.1.0",
-    "@opentelemetry/core": "1.3.1",
+    "@opentelemetry/api": "^1.6.0",
+    "@opentelemetry/core": "^1.17.0",
     "@remix-run/node": "2.0.0",
     "@remix-run/router": "1.9.0",
     "@remix-run/server-runtime": "2.0.0",

--- a/packages/instrumentation-remix/src/instrumentation.ts
+++ b/packages/instrumentation-remix/src/instrumentation.ts
@@ -3,6 +3,7 @@ import {
   InstrumentationBase,
   InstrumentationConfig,
   InstrumentationNodeModuleDefinition,
+  InstrumentationNodeModuleFile,
   isWrapped,
 } from "@opentelemetry/instrumentation";
 import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
@@ -60,28 +61,10 @@ export class RemixInstrumentation extends InstrumentationBase {
   }
 
   protected init() {
-    const remixRunServerRuntimeModule = new InstrumentationNodeModuleDefinition<typeof remixRunServerRuntime>(
-      "@remix-run/server-runtime",
-      [">=1.*"],
-      (moduleExports: typeof remixRunServerRuntime) => {
-        console.log("createRequestHandler:", moduleExports.createRequestHandler);
-        // createRequestHandler
-        if (isWrapped(moduleExports["createRequestHandler"])) {
-          this._unwrap(moduleExports, "createRequestHandler");
-        }
-        this._wrap(moduleExports, "createRequestHandler", this._patchCreateRequestHandler());
-
-        return moduleExports;
-      },
-      (moduleExports: typeof remixRunServerRuntime) => {
-        this._unwrap(moduleExports, "createRequestHandler");
-      }
-    );
-
-    const remixRunServerRuntimeRouteMatchingModule = new InstrumentationNodeModuleDefinition<
+    const remixRunServerRuntimeRouteMatchingFile = new InstrumentationNodeModuleFile<
       typeof remixRunServerRuntimeRouteMatching
     >(
-      "@remix-run/server-runtime/dist/routeMatching",
+      "@remix-run/server-runtime/dist/routeMatching.js",
       ["1.6.2 - 2.x"],
       (moduleExports: typeof remixRunServerRuntimeRouteMatching) => {
         // createRequestHandler
@@ -101,13 +84,13 @@ export class RemixInstrumentation extends InstrumentationBase {
      * Before Remix v1.6.2 we needed to wrap `@remix-run/server-runtime/routeMatching` module import instead of
      * `@remix-run/server-runtime/dist/routeMatching` module import. The wrapping logic is all the same though.
      */
-    const remixRunServerRuntimeRouteMatchingPre_1_6_2_Module = new InstrumentationNodeModuleDefinition<
+    const remixRunServerRuntimeRouteMatchingPre_1_6_2_File = new InstrumentationNodeModuleFile<
       typeof remixRunServerRuntimeRouteMatching
     >(
-      "@remix-run/server-runtime/routeMatching",
+      "@remix-run/server-runtime/routeMatching.js",
       ["1.0 - 1.6.1"],
       (moduleExports: typeof remixRunServerRuntimeRouteMatching) => {
-        // createRequestHandler
+        // matchServerRoutes
         if (isWrapped(moduleExports["matchServerRoutes"])) {
           this._unwrap(moduleExports, "matchServerRoutes");
         }
@@ -124,10 +107,8 @@ export class RemixInstrumentation extends InstrumentationBase {
      * Before Remix v1.6.2 we needed to wrap `@remix-run/server-runtime/data` module import instead of
      * `@remix-run/server-runtime/dist/data` module import. The wrapping logic is all the same though.
      */
-    const remixRunServerRuntimeDataPre_1_6_2_Module = new InstrumentationNodeModuleDefinition<
-      typeof remixRunServerRuntimeData
-    >(
-      "@remix-run/server-runtime/data",
+    const remixRunServerRuntimeDataPre_1_6_2_File = new InstrumentationNodeModuleFile<typeof remixRunServerRuntimeData>(
+      "@remix-run/server-runtime/data.js",
       ["1.0 - 1.6.1"],
       (moduleExports: typeof remixRunServerRuntimeData) => {
         // callRouteLoader
@@ -159,10 +140,8 @@ export class RemixInstrumentation extends InstrumentationBase {
      * Before Remix 1.7.3 we received the full `Match` object for each path in the route chain,
      * afterwards we only receive the `routeId` and associated `params`.
      */
-    const remixRunServerRuntimeDataPre_1_7_2_Module = new InstrumentationNodeModuleDefinition<
-      typeof remixRunServerRuntimeData
-    >(
-      "@remix-run/server-runtime/dist/data",
+    const remixRunServerRuntimeDataPre_1_7_2_File = new InstrumentationNodeModuleFile<typeof remixRunServerRuntimeData>(
+      "@remix-run/server-runtime/dist/data.js",
       ["1.6.2 - 1.7.2"],
       (moduleExports: typeof remixRunServerRuntimeData) => {
         // callRouteLoader
@@ -190,10 +169,8 @@ export class RemixInstrumentation extends InstrumentationBase {
       }
     );
 
-    const remixRunServerRuntimeDataPre_1_7_6_Module = new InstrumentationNodeModuleDefinition<
-      typeof remixRunServerRuntimeData
-    >(
-      "@remix-run/server-runtime/dist/data",
+    const remixRunServerRuntimeDataPre_1_7_6_File = new InstrumentationNodeModuleFile<typeof remixRunServerRuntimeData>(
+      "@remix-run/server-runtime/dist/data.js",
       ["1.7.3 - 1.7.6"],
       (moduleExports: typeof remixRunServerRuntimeData) => {
         // callRouteLoader
@@ -224,8 +201,8 @@ export class RemixInstrumentation extends InstrumentationBase {
     /*
      * In Remix 1.8.0, the callXXLoader functions were renamed to callXXLoaderRR.
      */
-    const remixRunServerRuntimeDataModule = new InstrumentationNodeModuleDefinition<typeof remixRunServerRuntimeData>(
-      "@remix-run/server-runtime/dist/data",
+    const remixRunServerRuntimeDataFile = new InstrumentationNodeModuleFile<typeof remixRunServerRuntimeData>(
+      "@remix-run/server-runtime/dist/data.js",
       ["1.8.0 - 2.x"],
       (moduleExports: typeof remixRunServerRuntimeData) => {
         // callRouteLoader
@@ -253,15 +230,32 @@ export class RemixInstrumentation extends InstrumentationBase {
       }
     );
 
-    return [
-      remixRunServerRuntimeModule,
-      remixRunServerRuntimeRouteMatchingModule,
-      remixRunServerRuntimeRouteMatchingPre_1_6_2_Module,
-      remixRunServerRuntimeDataPre_1_6_2_Module,
-      remixRunServerRuntimeDataPre_1_7_2_Module,
-      remixRunServerRuntimeDataPre_1_7_6_Module,
-      remixRunServerRuntimeDataModule,
-    ];
+    const remixRunServerRuntimeModule = new InstrumentationNodeModuleDefinition<typeof remixRunServerRuntime>(
+      "@remix-run/server-runtime",
+      [">=1.*"],
+      (moduleExports: typeof remixRunServerRuntime) => {
+        // createRequestHandler
+        if (isWrapped(moduleExports["createRequestHandler"])) {
+          this._unwrap(moduleExports, "createRequestHandler");
+        }
+        this._wrap(moduleExports, "createRequestHandler", this._patchCreateRequestHandler());
+
+        return moduleExports;
+      },
+      (moduleExports: typeof remixRunServerRuntime) => {
+        this._unwrap(moduleExports, "createRequestHandler");
+      },
+      [
+        remixRunServerRuntimeRouteMatchingFile,
+        remixRunServerRuntimeRouteMatchingPre_1_6_2_File,
+        remixRunServerRuntimeDataPre_1_6_2_File,
+        remixRunServerRuntimeDataPre_1_7_2_File,
+        remixRunServerRuntimeDataPre_1_7_6_File,
+        remixRunServerRuntimeDataFile,
+      ]
+    );
+
+    return remixRunServerRuntimeModule;
   }
 
   private _patchMatchServerRoutes(): (original: typeof remixRunServerRuntimeRouteMatching.matchServerRoutes) => any {

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,17 +955,10 @@
   resolved "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.27.0.tgz"
   integrity sha512-tB79288bwjkdhPNpw4UdOEy3bacVwtol6Que7cAu8KEJ9ULjRfSiwpYEwJY/oER3xZ7zNFz0uiJ7N1jSiotpVA==
 
-"@opentelemetry/api-metrics@0.29.2":
-  version "0.29.2"
-  resolved "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz"
-  integrity sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==
-  dependencies:
-    "@opentelemetry/api" "^1.0.0"
-
-"@opentelemetry/api@1.1.0", "@opentelemetry/api@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz"
-  integrity sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==
+"@opentelemetry/api@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz"
+  integrity sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==
 
 "@opentelemetry/context-async-hooks@1.0.1":
   version "1.0.1"
@@ -979,12 +972,12 @@
   dependencies:
     "@opentelemetry/semantic-conventions" "1.0.1"
 
-"@opentelemetry/core@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz"
-  integrity sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==
+"@opentelemetry/core@^1.17.0":
+  version "1.17.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-1.17.0.tgz"
+  integrity sha512-tfnl3h+UefCgx1aeN2xtrmr6BmdWGKXypk0pflQR0urFS40aE88trnkOMc2HTJZbMrqEEl4HsaBeFhwLVXsrJg==
   dependencies:
-    "@opentelemetry/semantic-conventions" "1.3.1"
+    "@opentelemetry/semantic-conventions" "1.17.0"
 
 "@opentelemetry/exporter-jaeger@^1.0.1":
   version "1.0.1"
@@ -1006,14 +999,15 @@
     semver "^7.3.2"
     shimmer "^1.2.1"
 
-"@opentelemetry/instrumentation@^0.29.2":
-  version "0.29.2"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.29.2.tgz"
-  integrity sha512-LXx5V0ONNATQFCE8C5uqnxWSm4rcXLssdLHdXjtGdxRmURqj/JO8jYefqXCD0LzsqEQ6yxOx2GZ0dgXvhBVdTw==
+"@opentelemetry/instrumentation@^0.43.0":
+  version "0.43.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.43.0.tgz"
+  integrity sha512-S1uHE+sxaepgp+t8lvIDuRgyjJWisAb733198kwQTUc9ZtYQ2V2gmyCtR1x21ePGVLoMiX/NWY7WA290hwkjJQ==
   dependencies:
-    "@opentelemetry/api-metrics" "0.29.2"
-    require-in-the-middle "^5.0.3"
-    semver "^7.3.2"
+    "@types/shimmer" "^1.0.2"
+    import-in-the-middle "1.4.2"
+    require-in-the-middle "^7.1.1"
+    semver "^7.5.2"
     shimmer "^1.2.1"
 
 "@opentelemetry/propagator-b3@1.0.1":
@@ -1064,22 +1058,22 @@
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz"
   integrity sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==
 
-"@opentelemetry/semantic-conventions@1.3.1", "@opentelemetry/semantic-conventions@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz"
-  integrity sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==
+"@opentelemetry/semantic-conventions@1.17.0", "@opentelemetry/semantic-conventions@^1.17.0":
+  version "1.17.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.17.0.tgz"
+  integrity sha512-+fguCd2d8d2qruk0H0DsCEy2CTK3t0Tugg7MhZ/UQMvmewbZLNnJ6heSYyzIZWG5IPfAXzoj4f4F/qpM7l4VBA==
 
 "@prisma/client@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.npmjs.org/@prisma/client/-/client-3.8.1.tgz"
-  integrity sha512-NxD1Xbkx1eT1mxSwo1RwZe665mqBETs0VxohuwNfFIxMqcp0g6d4TgugPxwZ4Jb4e5wCu8mQ9quMedhNWIWcZQ==
+  version "3.15.2"
+  resolved "https://registry.npmjs.org/@prisma/client/-/client-3.15.2.tgz"
+  integrity sha512-ErqtwhX12ubPhU4d++30uFY/rPcyvjk+mdifaZO5SeM21zS3t4jQrscy8+6IyB0GIYshl5ldTq6JSBo1d63i8w==
   dependencies:
-    "@prisma/engines-version" "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
+    "@prisma/engines-version" "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
 
-"@prisma/engines-version@3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f":
-  version "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
-  resolved "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz"
-  integrity sha512-G2JH6yWt6ixGKmsRmVgaQYahfwMopim0u/XLIZUo2o/mZ5jdu7+BL+2V5lZr7XiG1axhyrpvlyqE/c0OgYSl3g==
+"@prisma/engines-version@3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e":
+  version "3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+  resolved "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e.tgz"
+  integrity sha512-e3k2Vd606efd1ZYy2NQKkT4C/pn31nehyLhVug6To/q8JT8FpiMrDy7zmm3KLF0L98NOQQcutaVtAPhzKhzn9w==
 
 "@remix-run/node@2.0.0":
   version "2.0.0"
@@ -1316,6 +1310,11 @@
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz"
   integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
 
+"@types/shimmer@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.2.tgz"
+  integrity sha512-dKkr1bTxbEsFlh2ARpKzcaAmsYixqt9UyCdoEZk8rHyE4iQYcDCyvSjDSf7JUWJHlJiTtbIoQjxKh6ViywqDAg==
+
 "@types/sinon@^9.0.11":
   version "9.0.11"
   resolved "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.11.tgz"
@@ -1389,6 +1388,11 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
+acorn-import-assertions@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz"
+  integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
+
 acorn-jsx@^5.2.0:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
@@ -1408,6 +1412,11 @@ acorn@^8.4.1:
   version "8.7.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
+acorn@^8.8.2:
+  version "8.10.0"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz"
+  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
 after-all-results@^2.0.0:
   version "2.0.0"
@@ -1989,6 +1998,11 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+cjs-module-lexer@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz"
+  integrity sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -3760,6 +3774,16 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-in-the-middle@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz"
+  integrity sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==
+  dependencies:
+    acorn "^8.8.2"
+    acorn-import-assertions "^1.9.0"
+    cjs-module-lexer "^1.2.2"
+    module-details-from-path "^1.0.3"
+
 import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz"
@@ -3944,6 +3968,13 @@ is-ci@^2.0.0:
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
+
+is-core-module@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz"
+  integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
+  dependencies:
+    has "^1.0.3"
 
 is-core-module@^2.2.0, is-core-module@^2.5.0, is-core-module@^2.8.0:
   version "2.8.1"
@@ -6223,6 +6254,15 @@ require-in-the-middle@^5.0.3:
     module-details-from-path "^1.0.3"
     resolve "^1.12.0"
 
+require-in-the-middle@^7.1.1:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz"
+  integrity sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==
+  dependencies:
+    debug "^4.1.1"
+    module-details-from-path "^1.0.3"
+    resolve "^1.22.1"
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz"
@@ -6256,6 +6296,15 @@ resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.1
   integrity sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==
   dependencies:
     is-core-module "^2.8.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.22.1:
+  version "1.22.4"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz"
+  integrity sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==
+  dependencies:
+    is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -6383,6 +6432,13 @@ semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.5.2:
+  version "7.5.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -7226,9 +7282,9 @@ type-fest@^0.8.1:
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 type-fest@^4.0.0:
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.3.1.tgz"
-  integrity sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==
+  version "4.3.2"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.3.2.tgz"
+  integrity sha512-VpwuOgnTsQUUWi0id8Hl4/xiQ+OoaeJGe8dnFjzubJYe/lOc2/d1Qx/d3FqWR0FlpOG/cvukAXfB12A49Y4iiA==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Closes #32 

This PR fixes a warning on install by updating `@opentelemetry/instrumentation` to the latest version.

```
npm WARN deprecated @opentelemetry/api-metrics@0.29.2: Please use @opentelemetry/api >= 1.3.0
```

The update means that patches of internal imports need to be done by passing an array of `InstrumentationNodeModuleFile` to the main `InstrumentationNodeModuleDefinition`.
