### PR TITLE
fix(remix): support Remix v2.9

### DIFF
--- a/packages/instrumentation-remix/src/instrumentation.ts
+++ b/packages/instrumentation-remix/src/instrumentation.ts
@@ -169,9 +169,11 @@ export class RemixInstrumentation extends InstrumentationBase {
       }
     );
 
-    const remixRunServerRuntimeDataPre_1_7_6_File = new InstrumentationNodeModuleFile<typeof remixRunServerRuntimeData>(
+    const remixRunServerRuntimeDataPre_1_7_6_And_Post_2_9_File = new InstrumentationNodeModuleFile<
+      typeof remixRunServerRuntimeData
+    >(
       "@remix-run/server-runtime/dist/data.js",
-      ["1.7.3 - 1.7.6"],
+      ["1.7.3 - 1.7.6", "2.9.0 - 2.x"],
       (moduleExports: typeof remixRunServerRuntimeData) => {
         // callRouteLoader
         if (isWrapped(moduleExports["callRouteLoader"])) {
@@ -199,11 +201,13 @@ export class RemixInstrumentation extends InstrumentationBase {
     );
 
     /*
-     * In Remix 1.8.0, the callXXLoader functions were renamed to callXXLoaderRR.
+     * In Remix 1.8.0, the callXXLoader functions were renamed to callXXLoaderRR. They were renamed back in 2.9.0.
      */
-    const remixRunServerRuntimeDataFile = new InstrumentationNodeModuleFile<typeof remixRunServerRuntimeData>(
+    const remixRunServerRuntimeDataBetween_1_8_And_2_8_File = new InstrumentationNodeModuleFile<
+      typeof remixRunServerRuntimeData
+    >(
       "@remix-run/server-runtime/dist/data.js",
-      ["1.8.0 - 2.x"],
+      ["1.8.0 - 2.8.x"],
       (moduleExports: typeof remixRunServerRuntimeData) => {
         // callRouteLoader
         if (isWrapped(moduleExports["callRouteLoaderRR"])) {
@@ -250,8 +254,8 @@ export class RemixInstrumentation extends InstrumentationBase {
         remixRunServerRuntimeRouteMatchingPre_1_6_2_File,
         remixRunServerRuntimeDataPre_1_6_2_File,
         remixRunServerRuntimeDataPre_1_7_2_File,
-        remixRunServerRuntimeDataPre_1_7_6_File,
-        remixRunServerRuntimeDataFile,
+        remixRunServerRuntimeDataPre_1_7_6_And_Post_2_9_File,
+        remixRunServerRuntimeDataBetween_1_8_And_2_8_File,
       ]
     );
 


### PR DESCRIPTION
In https://github.com/remix-run/remix/pull/9142 the `RR` suffix was dropped from `callRouteLoader` and `callRouteAction`. This PR updates the Remix instrumentation so that it handles this change in v2.9.0.

Note that this doesn't include supporting the new [single fetch mode](https://remix.run/docs/en/main/guides/single-fetch).