### PR TITLE
feat(remix): add hook for reporting error

### DIFF
--- a/packages/instrumentation-remix/src/instrumentation.ts
+++ b/packages/instrumentation-remix/src/instrumentation.ts
@@ -38,6 +38,12 @@ export interface RemixInstrumentationConfig extends InstrumentationConfig {
    * Defaults to `false`, meaning that only span exception events are emitted.
    */
   legacyErrorAttributes?: boolean;
+
+  /**
+   * Function to add error to the span. By default, it adds error as an exception event and sets the span status to error.
+   * You can override this function to add custom error handling logic.
+   */
+  addErrorToSpan?: (span: Span, error: Error) => void;
 }
 
 const DEFAULT_CONFIG: RemixInstrumentationConfig = {
@@ -425,7 +431,7 @@ export class RemixInstrumentation extends InstrumentationBase {
                   const formData = await clonedRequest.formData();
                   const { actionFormDataAttributes: actionFormAttributes } = plugin.getConfig();
                   formData.forEach((value, key) => {
-                    if (actionFormAttributes[key] && actionFormAttributes[key] !== false) {
+                    if (actionFormAttributes[key]) {
                       const keyName = actionFormAttributes[key] === true ? key : actionFormAttributes[key];
                       span.setAttribute(`formData.${keyName}`, value.toString());
                     }
@@ -480,7 +486,7 @@ export class RemixInstrumentation extends InstrumentationBase {
                   const formData = await clonedRequest.formData();
                   const { actionFormDataAttributes: actionFormAttributes } = plugin.getConfig();
                   formData.forEach((value, key) => {
-                    if (actionFormAttributes[key] && actionFormAttributes[key] !== false) {
+                    if (actionFormAttributes[key]) {
                       const keyName = actionFormAttributes[key] === true ? key : actionFormAttributes[key];
                       span.setAttribute(`formData.${keyName}`, value.toString());
                     }
@@ -506,9 +512,15 @@ export class RemixInstrumentation extends InstrumentationBase {
   }
 
   private addErrorToSpan(span: Span, error: Error) {
+    const config = this.getConfig();
+    if (config.addErrorToSpan) {
+      config.addErrorToSpan(span, error);
+      return;
+    }
+
     addErrorEventToSpan(span, error);
 
-    if (this.getConfig().legacyErrorAttributes || false) {
+    if (config.legacyErrorAttributes || false) {
       addErrorAttributesToSpan(span, error);
     }
   }


### PR DESCRIPTION
I'm unfortunately using application insights and if the parent span is not of type SERVER, reportException goes nowhere.

I have a custom reportException function which handles the oddities of app insights and need a hook into this so I can control how errors are reported.