### PR TITLE
feat: set HTTP route id

### DIFF
--- a/packages/instrumentation-remix/src/instrumentation.ts
+++ b/packages/instrumentation-remix/src/instrumentation.ts
@@ -8,6 +8,8 @@ import {
 } from "@opentelemetry/instrumentation";
 import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
 
+import { getRPCMetadata, RPCType } from "@opentelemetry/core";
+
 import type * as remixRunServerRuntime from "@remix-run/server-runtime";
 import type * as remixRunServerRuntimeRouteMatching from "@remix-run/server-runtime/dist/routeMatching";
 import type { RouteMatch } from "@remix-run/server-runtime/dist/routeMatching";
@@ -274,6 +276,12 @@ export class RemixInstrumentation extends InstrumentationBase {
         if (span && routeId) {
           span.setAttribute(RemixSemanticAttributes.MATCH_ROUTE_ID, routeId);
         }
+
+        const rpcMetadata = getRPCMetadata(opentelemetry.context.active());
+        if (rpcMetadata?.type === RPCType.HTTP) {
+          rpcMetadata.route = routeId;
+        }
+
 
         return result;
       };


### PR DESCRIPTION
This is the only way I found to have the `http_route` set in the metrics, ie

![image](https://github.com/user-attachments/assets/df0cd8f3-3e7f-48d1-b257-2e78a67e3bae)


Based on the express implem: https://github.com/open-telemetry/opentelemetry-js-contrib/blob/b043ffbe17947409c0ae9ea6fabe6ab1ec5b4cc9/plugins/node/opentelemetry-instrumentation-express/src/instrumentation.ts#L188-L191